### PR TITLE
Serveme

### DIFF
--- a/api.go
+++ b/api.go
@@ -32,13 +32,14 @@ var (
 //nolint:funlen
 func loadProfiles(ctx context.Context, database *pgStore, cache cache, steamIDs steamid.Collection) ([]domain.Profile, error) {
 	var ( //nolint:prealloc
-		waitGroup  = &sync.WaitGroup{}
-		summaries  []steamweb.PlayerSummary
-		bans       []steamweb.PlayerBanState
-		profiles   []domain.Profile
-		logs       map[steamid.SteamID]int
-		friends    friendMap
-		sourceBans BanRecordMap
+		waitGroup   = &sync.WaitGroup{}
+		summaries   []steamweb.PlayerSummary
+		bans        []steamweb.PlayerBanState
+		profiles    []domain.Profile
+		logs        map[steamid.SteamID]int
+		friends     friendMap
+		servemeBans []*domain.ServeMeRecord
+		sourceBans  BanRecordMap
 	)
 
 	if len(steamIDs) > maxResults {
@@ -100,6 +101,21 @@ func loadProfiles(ctx context.Context, database *pgStore, cache cache, steamIDs 
 	go func() {
 		defer waitGroup.Done()
 
+		serveme, errs := database.getServeMeRecords(localCtx, steamIDs)
+		if errs != nil && !errors.Is(errs, errDatabaseNoResults) {
+			slog.Error("Failed to get serveme records")
+
+			return
+		}
+
+		servemeBans = serveme
+	}()
+
+	waitGroup.Add(1)
+
+	go func() {
+		defer waitGroup.Done()
+
 		logsVal, err := database.getLogsTFCount(localCtx, steamIDs)
 		if err != nil {
 			slog.Error("failed to query log counts", ErrAttr(err))
@@ -130,6 +146,14 @@ func loadProfiles(ctx context.Context, database *pgStore, cache cache, steamIDs 
 		for _, ban := range bans {
 			if ban.SteamID == sid {
 				profile.BanState = ban
+
+				break
+			}
+		}
+
+		for _, serveme := range servemeBans {
+			if serveme.SteamID == sid {
+				profile.ServeMe = serveme
 
 				break
 			}
@@ -262,6 +286,7 @@ func createRouter(database *pgStore, cacheHandler cache) (*http.ServeMux, error)
 	mux.HandleFunc("GET /bd", handleGetBotDetector(database))
 	mux.HandleFunc("GET /log/player/{steam_id}", handleGetLogsSummary(database))
 	mux.HandleFunc("GET /log/player/{steam_id}/list", handleGetLogsList(database))
+	mux.HandleFunc("GET /serveme", handleGetServemeList(database))
 
 	return mux, nil
 }

--- a/api.go
+++ b/api.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"html/template"
 	"log/slog"
@@ -210,10 +209,7 @@ func renderResponse(writer http.ResponseWriter, request *http.Request, status in
 	writer.Header().Set("Content-Type", "application/json")
 	writer.WriteHeader(status)
 
-	enc := json.NewEncoder(writer)
-	enc.SetIndent("", "    ")
-
-	if errWrite := enc.Encode(data); errWrite != nil {
+	if errWrite := encodeJSONIndent(writer, data); errWrite != nil {
 		slog.Error("failed to write out json response", ErrAttr(errWrite))
 	}
 }

--- a/api_handler.go
+++ b/api_handler.go
@@ -339,3 +339,20 @@ func handleGetLogsList(database *pgStore) http.HandlerFunc {
 		responseOk(writer, request, logs, fmt.Sprintf("Logs.tf List %s", steamID.String()))
 	}
 }
+
+func handleGetServemeList(database *pgStore) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		list, err := database.getServeMeList(request.Context())
+		if err != nil && !errors.Is(err, errDatabaseNoResults) {
+			responseErr(writer, request, http.StatusInternalServerError, errInternalError, "Unhandled error")
+
+			return
+		}
+
+		if list == nil {
+			list = []domain.ServeMeRecord{}
+		}
+
+		responseOk(writer, request, list, fmt.Sprintf("Serveme Ban Records (%d)", len(list)))
+	}
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -253,6 +253,258 @@ Return a list for a single steam id: http://localhost:8888/sourcebans/7656119897
 }
 ```
 
+## /bd
+
+Search tracked bot detector lists.
+
+Example: http://localhost:8888/bd?steamids=76561199176781392
+
+```json
+[
+    {
+        "list_name": "joekiller",
+        "match": {
+            "attributes": [
+                "cheater"
+            ],
+            "last_seen": {
+                "player_name": "Whiâ€te Madnesâ€s",
+                "time": 1708860576
+            },
+            "steamid": "76561199176781392",
+            "proof": []
+        }
+    },
+    {
+        "list_name": "@trusted",
+        "match": {
+            "attributes": [
+                "cheater"
+            ],
+            "last_seen": {
+                "player_name": "DISCO MOUâ€SEâ€â€â€",
+                "time": 1623984811
+            },
+            "steamid": "76561199176781392",
+            "proof": []
+        }
+    }
+]
+```
+
+## /log/{log_id}
+
+Get a logs.tf match
+
+Examples (truncated): http://localhost:8888/log/3000
+
+```json
+{
+    "log_id": 3000,
+    "title": "evening-l0108007.log",
+    "map": "freight",
+    "format": "",
+    "duration": 1784,
+    "score_red": 3,
+    "score_blu": 0,
+    "created_on": "2013-01-08T19:46:03-07:00",
+    "rounds": [],
+    "players": [
+        {
+            "steam_id": "76561197960460584",
+            "team": 3,
+            "name": "diaz",
+            "classes": null,
+            "kills": 21,
+            "assists": 12,
+            "deaths": 15,
+            "damage": 6464,
+            "dpm": 217,
+            "kad": 2.2,
+            "kd": 1.4,
+            "damage_taken": 0,
+            "dtm": 0,
+            "health_packs": 14,
+            "backstabs": 13,
+            "headshots": 4,
+            "airshots": 0,
+            "caps": 0,
+            "healing_taken": 0
+        },
+        {
+            "steam_id": "76561197989627594",
+            "team": 4,
+            "name": "Max!",
+            "classes": null,
+            "kills": 22,
+            "assists": 3,
+            "deaths": 23,
+            "damage": 7319,
+            "dpm": 246,
+            "kad": 1.1,
+            "kd": 1,
+            "damage_taken": 0,
+            "dtm": 0,
+            "health_packs": 41,
+            "backstabs": 5,
+            "headshots": 2,
+            "airshots": 0,
+            "caps": 0,
+            "healing_taken": 0
+        }
+    ],
+    "medics": [
+        {
+            "steam_id": "76561197993564443",
+            "healing": 6281,
+            "healing_per_min": 0,
+            "charges_kritz": 0,
+            "charges_quickfix": 0,
+            "charges_medigun": 18,
+            "charges_vacc": 0,
+            "drops": 0,
+            "avg_time_build": 0,
+            "avg_time_use": 0,
+            "near_full_death": 0,
+            "avg_uber_len": 0,
+            "death_after_charge": 0,
+            "major_adv_lost": 0,
+            "biggest_adv_lost": 0
+        },
+        {
+            "steam_id": "76561198000024718",
+            "healing": 6737,
+            "healing_per_min": 0,
+            "charges_kritz": 0,
+            "charges_quickfix": 0,
+            "charges_medigun": 8,
+            "charges_vacc": 0,
+            "drops": 0,
+            "avg_time_build": 0,
+            "avg_time_use": 0,
+            "near_full_death": 0,
+            "avg_uber_len": 0,
+            "death_after_charge": 0,
+            "major_adv_lost": 0,
+            "biggest_adv_lost": 0
+        }
+    ]
+}
+
+```
+
+## /log/player/{steam_id}
+
+Get a summary of a users logs.tf data.
+
+Example: http://localhost:8888/log/player/76561197960831093
+
+```json
+{
+    "logs": 480,
+    "kills_avg": 23.02,
+    "assists_avg": 9.78,
+    "deaths_avg": 16.09,
+    "damage_avg": 6338.83,
+    "dpm_avg": 262.76,
+    "kad_avg": 2.67,
+    "kd_avg": 1.89,
+    "damage_taken_avg": 782.94,
+    "dtm_avg": 37.31,
+    "health_packs_avg": 20.41,
+    "backstabs_avg": 3.02,
+    "headshots_avg": 1.69,
+    "airshots_avg": 0,
+    "caps_avg": 0.4,
+    "healing_taken_avg": 0,
+    "kills_sum": 11051,
+    "assists_sum": 4696,
+    "deaths_sum": 7724,
+    "damage_sum": 3042640,
+    "damage_taken_sum": 375813,
+    "health_packs_sum": 9796,
+    "backstabs_sum": 1450,
+    "headshots_sum": 813,
+    "airshots_sum": 0,
+    "caps_sum": 194,
+    "healing_taken_sum": 0
+}
+
+```
+
+## /log/player/{steam_id}/list
+
+Get a high level list of a users logs.tf matches.
+
+Example: http://localhost:8888/log/player/76561197960831093/list
+
+```json
+[
+  {
+    "log_id": 3,
+    "title": "Log 3",
+    "map": "",
+    "format": "",
+    "duration": 1769,
+    "score_red": 1,
+    "score_blu": 1,
+    "created_on": "2012-11-18T14:46:05-07:00"
+  },
+  {
+    "log_id": 13,
+    "title": "Log 13",
+    "map": "",
+    "format": "",
+    "duration": 1984,
+    "score_red": 5,
+    "score_blu": 4,
+    "created_on": "2012-11-20T16:15:45-07:00"
+  },
+  {
+    "log_id": 12,
+    "title": "Log 12",
+    "map": "",
+    "format": "",
+    "duration": 1769,
+    "score_red": 1,
+    "score_blu": 1,
+    "created_on": "2012-11-20T16:15:22-07:00"
+  }
+]
+```
+
+## /serveme
+
+Get a list of current serveme.tf bans.
+
+Example: http://localhost:8888/serveme
+
+```json
+[
+    {
+        "steam_id": "76561199176100193",
+        "name": "bot/cheat dev",
+        "reason": "bot/cheat dev",
+        "deleted": false,
+        "created_on": "2024-07-11T04:27:45.81104-06:00"
+    },
+    {
+        "steam_id": "76561199176117137",
+        "name": "bot/cheat dev",
+        "reason": "bot/cheat dev",
+        "deleted": false,
+        "created_on": "2024-07-11T04:27:45.81104-06:00"
+    },
+    {
+        "steam_id": "76561199176183082",
+        "name": "bot/cheat dev",
+        "reason": "bot/cheat dev",
+        "deleted": false,
+        "created_on": "2024-07-11T04:27:45.81104-06:00"
+    }
+]
+```
+
 
 ## Content Types
 

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -191,6 +191,7 @@ type Profile struct {
 	Seasons    []Season                `json:"seasons"`
 	Friends    []steamweb.Friend       `json:"friends"`
 	SourceBans []SbBanRecord           `json:"source_bans"`
+	ServeMe    *ServeMeRecord          `json:"serve_me"`
 	LogsCount  int                     `json:"logs_count"`
 }
 
@@ -411,4 +412,12 @@ type LogsTFPlayerSummary struct {
 	Logs int `json:"logs"`
 	LogsTFPlayerAverages
 	LogsTFPlayerSums
+}
+
+type ServeMeRecord struct {
+	SteamID steamid.SteamID `json:"steam_id"`
+	Name    string          `json:"name"`
+	Reason  string          `json:"reason"`
+	Deleted bool            `json:"deleted"`
+	TimeStamped
 }

--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ func run(ctx context.Context) int {
 
 	go listUpdater(ctx, database)
 	go profileUpdater(ctx, database)
+	go startServeMeUpdater(ctx, database)
 
 	return runHTTP(ctx, router, config.ListenAddr)
 }

--- a/migrations/0004_serveme_table.down.sql
+++ b/migrations/0004_serveme_table.down.sql
@@ -1,0 +1,5 @@
+begin;
+
+drop table if exists serveme;
+
+commit;

--- a/migrations/0004_serveme_table.up.sql
+++ b/migrations/0004_serveme_table.up.sql
@@ -1,0 +1,13 @@
+begin;
+
+create table if not exists serveme
+(
+    steam_id   bigint primary key references player (steam_id),
+    name       text        not null default '',
+    reason     text        not null default '',
+    deleted    boolean     not null default false,
+    created_on timestamptz not null,
+    updated_on  timestamptz not null
+);
+
+commit;

--- a/serveme.go
+++ b/serveme.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"encoding/csv"
 	"errors"
-	"github.com/leighmacdonald/bd-api/domain"
-	"github.com/leighmacdonald/steamid/v4/steamid"
 	"io"
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/leighmacdonald/bd-api/domain"
+	"github.com/leighmacdonald/steamid/v4/steamid"
 )
 
-var (
-	errReadCSVRows = errors.New("failed to read csv rows")
-)
+var errReadCSVRows = errors.New("failed to read csv rows")
 
 func startServeMeUpdater(ctx context.Context, database *pgStore) {
 	updateServeMe(ctx, database)

--- a/serveme.go
+++ b/serveme.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"github.com/leighmacdonald/bd-api/domain"
+	"github.com/leighmacdonald/steamid/v4/steamid"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+var (
+	errReadCSVRows = errors.New("failed to read csv rows")
+)
+
+func startServeMeUpdater(ctx context.Context, database *pgStore) {
+	updateServeMe(ctx, database)
+
+	ticker := time.NewTicker(time.Hour * 6)
+	for {
+		select {
+		case <-ticker.C:
+			updateServeMe(ctx, database)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func updateServeMe(ctx context.Context, database *pgStore) {
+	entries, errDownload := downloadServeMeList(ctx)
+	if errDownload != nil {
+		slog.Error("Failed to download serveme list", ErrAttr(errDownload))
+
+		return
+	}
+
+	if len(entries) == 0 {
+		return
+	}
+
+	// Ensure FK's are satisfied
+	for _, entry := range entries {
+		record := PlayerRecord{
+			Player: domain.Player{
+				SteamID:     entry.SteamID,
+				PersonaName: entry.Name,
+			},
+			isNewRecord: true,
+		}
+
+		if err := database.playerGetOrCreate(ctx, entry.SteamID, &record); err != nil {
+			slog.Error("Failed to ensure player exists", ErrAttr(err))
+
+			return
+		}
+	}
+
+	if err := database.updateServeMeList(ctx, entries); err != nil {
+		slog.Error("Failed to save serveme list", ErrAttr(err))
+
+		return
+	}
+
+	slog.Info("Inserted serveme records", slog.Int("count", len(entries)))
+}
+
+func downloadServeMeList(ctx context.Context) ([]domain.ServeMeRecord, error) {
+	client := NewHTTPClient()
+	req, errReq := http.NewRequestWithContext(ctx, http.MethodGet, "https://raw.githubusercontent.com/Arie/serveme/master/doc/banned_steam_ids.csv", nil)
+	if errReq != nil {
+		return nil, errors.Join(errReq, errRequestCreate)
+	}
+
+	resp, errResp := client.Do(req)
+	if errResp != nil {
+		return nil, errors.Join(errResp, errRequestPerform)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("failed to close serveme response body", ErrAttr(err))
+		}
+	}()
+
+	reader := csv.NewReader(resp.Body)
+	reader.FieldsPerRecord = 3
+	reader.TrimLeadingSpace = true
+
+	now := time.Now()
+
+	var records []domain.ServeMeRecord
+	for {
+		row, errRows := reader.Read()
+		if errRows == io.EOF {
+			break
+		}
+
+		if errRows != nil {
+			return nil, errors.Join(errRows, errReadCSVRows)
+		}
+
+		if len(row) != 3 {
+			continue
+		}
+
+		sid := steamid.New(row[0])
+		if !sid.Valid() {
+			slog.Warn("Got invalid serveme steamid", slog.String("steam_id", row[0]))
+
+			continue
+		}
+
+		records = append(records, domain.ServeMeRecord{
+			SteamID: sid,
+			Name:    row[1],
+			Reason:  row[2],
+			Deleted: false,
+			TimeStamped: domain.TimeStamped{
+				UpdatedOn: now,
+				CreatedOn: now,
+			},
+		})
+	}
+
+	return records, nil
+}

--- a/template.go
+++ b/template.go
@@ -38,12 +38,6 @@ func (s *styleEncoder) Encode(value any) (string, string, error) {
 		return "", "", err
 	}
 
-	jsonEncoder := json.NewEncoder(&jsonBody)
-	jsonEncoder.SetIndent("", "    ")
-	if errJSON := jsonEncoder.Encode(value); errJSON != nil {
-		return "", "", errors.Join(errJSON, errResponseJSON)
-	}
-
 	iterator, errTokenize := s.lexer.Tokenise(&chroma.TokeniseOptions{State: "root", EnsureLF: true}, jsonBody.String())
 	if errTokenize != nil {
 		return "", "", errors.Join(errTokenize, errResponseTokenize)

--- a/template.go
+++ b/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/formatters/html"
@@ -32,6 +33,11 @@ func newStyleEncoder() *styleEncoder {
 
 func (s *styleEncoder) Encode(value any) (string, string, error) {
 	var jsonBody bytes.Buffer
+
+	if err := encodeJSONIndent(&jsonBody, value); err != nil {
+		return "", "", err
+	}
+
 	jsonEncoder := json.NewEncoder(&jsonBody)
 	jsonEncoder.SetIndent("", "    ")
 	if errJSON := jsonEncoder.Encode(value); errJSON != nil {
@@ -54,4 +60,14 @@ func (s *styleEncoder) Encode(value any) (string, string, error) {
 	}
 
 	return cssBuf.String(), bodyBuf.String(), nil
+}
+
+func encodeJSONIndent(w io.Writer, value any) error {
+	jsonEncoder := json.NewEncoder(w)
+	jsonEncoder.SetIndent("", "    ")
+	if errJSON := jsonEncoder.Encode(value); errJSON != nil {
+		return errors.Join(errJSON, errResponseJSON)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Adds support for indexing and querying the serveme.tf bans.

- ` GET /serveme` Returns all known records

Adds `serve_me` property to profile.

API docs updated.

closes #6 