### PR TITLE
Add datasources to stats

### DIFF
--- a/api_handler.go
+++ b/api_handler.go
@@ -375,6 +375,37 @@ func handleGetStats(database *pgStore) func(http.ResponseWriter, *http.Request) 
 				return
 			}
 
+			lists, errLists := database.botDetectorLists(request.Context())
+			if errLists != nil && !errors.Is(errLists, errDatabaseNoResults) {
+				responseErr(writer, request, http.StatusInternalServerError, errLists, "Failed to generate stats")
+
+				return
+			}
+
+			for _, list := range lists {
+				newStats.BotDetectorLists = append(newStats.BotDetectorLists, domain.BDListBasic{
+					Name: list.BDListName,
+					URL:  list.URL,
+				})
+			}
+
+			sourcebans, errSB := database.sourcebansSites(request.Context())
+			if errSB != nil && !errors.Is(errSB, errDatabaseNoResults) {
+				responseErr(writer, request, http.StatusInternalServerError, errSB, "Failed to generate stats")
+
+				return
+			}
+
+			for _, site := range sourcebans {
+				newStats.SourcebansSites = append(newStats.SourcebansSites, string(site.Name))
+			}
+
+			slices.SortFunc(newStats.BotDetectorLists, func(a, b domain.BDListBasic) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+
+			slices.Sort(newStats.SourcebansSites)
+
 			statsMu.Lock()
 			updated = time.Now()
 			stats = newStats
@@ -383,37 +414,6 @@ func handleGetStats(database *pgStore) func(http.ResponseWriter, *http.Request) 
 
 		statsMu.RLock()
 		defer statsMu.RUnlock()
-
-		lists, errLists := database.botDetectorLists(request.Context())
-		if errLists != nil && !errors.Is(errLists, errDatabaseNoResults) {
-			responseErr(writer, request, http.StatusInternalServerError, errLists, "Failed to generate stats")
-
-			return
-		}
-
-		for _, list := range lists {
-			stats.BotDetectorLists = append(stats.BotDetectorLists, domain.BDListBasic{
-				Name: list.BDListName,
-				URL:  list.URL,
-			})
-		}
-
-		sourcebans, errSB := database.sourcebansSites(request.Context())
-		if errSB != nil && !errors.Is(errSB, errDatabaseNoResults) {
-			responseErr(writer, request, http.StatusInternalServerError, errSB, "Failed to generate stats")
-
-			return
-		}
-
-		for _, site := range sourcebans {
-			stats.SourcebansSites = append(stats.SourcebansSites, string(site.Name))
-		}
-
-		slices.SortFunc(stats.BotDetectorLists, func(a, b domain.BDListBasic) int {
-			return cmp.Compare(a.Name, b.Name)
-		})
-
-		slices.Sort(stats.SourcebansSites)
 
 		responseOk(writer, request, stats, "Global Site Stats")
 	}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -496,3 +496,8 @@ type BDListEntry struct {
 	CreatedOn     time.Time
 	UpdatedOn     time.Time
 }
+
+type BDListBasic struct {
+	Name string
+	URL  string
+}


### PR DESCRIPTION
Add the bot detector and sourcebans sites used as data sources to the `/stats` endpoint.