### PR TITLE
Support for ETF2L Bans

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
     - bodyclose
     - containedctx
     #- contextcheck
-    - cyclop
+    #- cyclop
     - decorder
     #- depguard
     - dogsled
@@ -37,9 +37,9 @@ linters:
     #- gocognit
     #- goconst
     - gocritic
-    - gocyclo
+    #- gocyclo
     - godot
-    - godox
+    #- godox
     - err113
     - gofmt
     - gofumpt

--- a/api.go
+++ b/api.go
@@ -58,8 +58,10 @@ func createRouter(database *pgStore, cacheHandler cache, config appConfig) (*htt
 	mux.HandleFunc("GET /", handleGetIndex())
 	mux.HandleFunc("GET /stats", handleGetStats(database))
 	mux.HandleFunc("GET /list/rgl", handleGetRGLList(database, config))
+	mux.HandleFunc("GET /list/etf2l", handleGetETF2LList(database, config))
 	mux.HandleFunc("GET /list/serveme", handleGetServemeListBD(database, config))
 	mux.HandleFunc("GET /rgl/player_history", handleGetRGLPlayerHistory(database))
+	mux.HandleFunc("GET /league_bans", handleGetLeagueBans(database))
 
 	return mux, nil
 }

--- a/config.go
+++ b/config.go
@@ -41,6 +41,7 @@ type appConfig struct {
 	LogstfScraperEnabled     bool            `mapstructure:"logstf_scraper_enabled"`
 	SourcebansScraperEnabled bool            `mapstructure:"sourcebans_scraper_enabled"`
 	RGLScraperEnabled        bool            `mapstructure:"rgl_scraper_enabled"`
+	ETF2LScraperEnabled      bool            `mapstructure:"etf2l_scraper_enabled"`
 	ProxiesEnabled           bool            `mapstructure:"proxies_enabled"`
 	Proxies                  []*proxyContext `mapstructure:"proxies"`
 	ScrapeDelay              int             `mapstructure:"scrape_delay"`

--- a/docs/API.md
+++ b/docs/API.md
@@ -197,6 +197,26 @@ Example: https://bd-api.roto.lol/profile?steamids=76561197970669109,765611979928
       "deleted": false,
       "created_on": "2024-07-18T01:36:27.686317-06:00"
     },
+    "league_bans": {
+      "etf2l": [
+        {
+          "steam_id": "76561199234205416",
+          "alias": "test",
+          "expires_at": "2037-12-30T16:00:00-07:00",
+          "created_at": "2024-07-07T12:52:19-06:00",
+          "reason": "Cheating"
+        }
+      ],
+      "rgl": [
+        {
+          "steam_id": "76561199234205416",
+          "alias": "test",
+          "expires_at": "2019-08-31T23:00:00-06:00",
+          "created_at": "2019-04-10T22:37:49-06:00",
+          "reason": "Using an in-game exploit that messes with hitboxes during playoff match."
+        }
+      ]
+    },
     "logs_count": 0,
     "bot_detector": [
       {

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -528,3 +528,6 @@ type RGLBan struct {
 	CreatedAt time.Time       `json:"created_at"`
 	Reason    string          `json:"reason"`
 }
+
+// ETF2LBan aliases the RGLBan model which is already good, just make it more obvious what it is.
+type ETF2LBan RGLBan

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -191,6 +191,7 @@ type Profile struct {
 	BanState    PlayerBanState         `json:"ban_state"`
 	SourceBans  []SbBanRecord          `json:"source_bans"`
 	ServeMe     *ServeMeRecord         `json:"serve_me"`
+	LeagueBans  map[League][]any       `json:"league_bans"`
 	LogsCount   int                    `json:"logs_count"`
 	BotDetector []BDSearchResult       `json:"bot_detector"`
 	RGL         []RGLPlayerTeamHistory `json:"rgl"`
@@ -531,3 +532,12 @@ type RGLBan struct {
 
 // ETF2LBan aliases the RGLBan model which is already good, just make it more obvious what it is.
 type ETF2LBan RGLBan
+
+type LeagueBanMap map[steamid.SteamID]map[League][]any
+
+type League string
+
+const (
+	RGL   League = "rgl"
+	ETF2L League = "rgl"
+)

--- a/etf2l.go
+++ b/etf2l.go
@@ -3,16 +3,15 @@ package main
 import (
 	"context"
 	"errors"
-	"github.com/leighmacdonald/bd-api/domain"
-	"github.com/leighmacdonald/etf2l"
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/leighmacdonald/bd-api/domain"
+	"github.com/leighmacdonald/etf2l"
 )
 
-var (
-	errETF2LFetchBans = errors.New("failed to fetch etf2l bans")
-)
+var errETF2LFetchBans = errors.New("failed to fetch etf2l bans")
 
 type ETF2LScraper struct {
 	database   *pgStore
@@ -58,7 +57,7 @@ func (e *ETF2LScraper) updateBans(ctx context.Context) error {
 		return errors.Join(errBans, errETF2LFetchBans)
 	}
 
-	var eBans []domain.ETF2LBan
+	var eBans []domain.ETF2LBan //nolint:prealloc
 
 	for _, ban := range bans {
 		if !ban.Steamid64.Valid() {

--- a/etf2l.go
+++ b/etf2l.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"github.com/leighmacdonald/bd-api/domain"
+	"github.com/leighmacdonald/etf2l"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+var (
+	errETF2LFetchBans = errors.New("failed to fetch etf2l bans")
+)
+
+type ETF2LScraper struct {
+	database   *pgStore
+	client     *etf2l.Client
+	httpClient *http.Client
+}
+
+func NewETF2LScraper(database *pgStore) ETF2LScraper {
+	return ETF2LScraper{
+		database:   database,
+		client:     etf2l.New(),
+		httpClient: NewHTTPClient(),
+	}
+}
+
+func (e *ETF2LScraper) start(ctx context.Context) {
+	e.scrape(ctx)
+
+	ticker := time.NewTicker(time.Hour * 6)
+
+	for {
+		select {
+		case <-ticker.C:
+			e.scrape(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (e *ETF2LScraper) scrape(ctx context.Context) {
+	if err := e.updateBans(ctx); err != nil {
+		slog.Error("Failed to update ETF2L bans", ErrAttr(err))
+	}
+}
+
+func (e *ETF2LScraper) updateBans(ctx context.Context) error {
+	bans, errBans := e.client.Bans(ctx, e.httpClient, etf2l.BanOpts{
+		Recursive: etf2l.BaseOpts{Recursive: true},
+	})
+
+	if errBans != nil {
+		return errors.Join(errBans, errETF2LFetchBans)
+	}
+
+	var eBans []domain.ETF2LBan
+
+	for _, ban := range bans {
+		if !ban.Steamid64.Valid() {
+			continue
+		}
+
+		eBans = append(eBans, domain.ETF2LBan{
+			SteamID:   ban.Steamid64,
+			Alias:     ban.Name,
+			ExpiresAt: time.Unix(int64(ban.End), 0).Truncate(time.Second),
+			CreatedAt: time.Unix(int64(ban.Start), 0).Truncate(time.Second),
+			Reason:    ban.Reason,
+		})
+	}
+
+	if err := e.database.etf2lBansUpdate(ctx, eBans); err != nil {
+		return dbErr(err, "failed to update etf2l bans")
+	}
+
+	slog.Info("Got ETF2L bans", slog.Int("count", len(bans)))
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.17.1
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.6.0
+	github.com/leighmacdonald/etf2l v0.0.0-20240730061846-bfcc1ef54a90
 	github.com/leighmacdonald/rgl v0.0.0-20240729075133-fdd39c1890c8
 	github.com/leighmacdonald/steamid/v4 v4.0.4
 	github.com/leighmacdonald/steamweb/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -142,6 +143,7 @@ github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65 h1:DadwsjnMwFjfWc9y5W
 github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65/go.mod h1:5R2h2EEX+qri8jOWMbJCtaPWkrrNc7OHwsp2TCqp7ak=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
@@ -174,6 +176,7 @@ github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgt
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
@@ -197,6 +200,14 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
+github.com/leighmacdonald/etf2l v0.0.0-20240312233456-a1fd1c1439af h1:W9kMGPWxK9DJijA41lWITd5PjihvwLn17i8FYg6hu60=
+github.com/leighmacdonald/etf2l v0.0.0-20240312233456-a1fd1c1439af/go.mod h1:DEby5kOY42RNdoBXaj3kzeO7P1rmUM3yfloCdOUvH4w=
+github.com/leighmacdonald/etf2l v0.0.0-20240730024437-9b8bea3d66a7 h1:I+rZfYzSWjCXpitFmcnucYVEenv1ywVu9WEM3K3mbGw=
+github.com/leighmacdonald/etf2l v0.0.0-20240730024437-9b8bea3d66a7/go.mod h1:DEby5kOY42RNdoBXaj3kzeO7P1rmUM3yfloCdOUvH4w=
+github.com/leighmacdonald/etf2l v0.0.0-20240730024751-5fb7bf93418b h1:5OBZwGfKiJp/9aGxZJuTz5WF5dsjzT92M1kOICka4Wo=
+github.com/leighmacdonald/etf2l v0.0.0-20240730024751-5fb7bf93418b/go.mod h1:DEby5kOY42RNdoBXaj3kzeO7P1rmUM3yfloCdOUvH4w=
+github.com/leighmacdonald/etf2l v0.0.0-20240730061846-bfcc1ef54a90 h1:J2joTSkDHLs6IbMsCa9YwZPKpwV45wzPPaFeFRbnuLc=
+github.com/leighmacdonald/etf2l v0.0.0-20240730061846-bfcc1ef54a90/go.mod h1:DEby5kOY42RNdoBXaj3kzeO7P1rmUM3yfloCdOUvH4w=
 github.com/leighmacdonald/rgl v0.0.0-20240729075133-fdd39c1890c8 h1:4ReiqR/70RD4rWdaRDrdImHLNT4gpIo1QU5JXvIFBIU=
 github.com/leighmacdonald/rgl v0.0.0-20240729075133-fdd39c1890c8/go.mod h1:kRe6HzIXwqipu2vcM5Toei7S329NGBswM6pQo6hWZvI=
 github.com/leighmacdonald/steamid/v4 v4.0.4 h1:YtTi/uU8kKLaEH/oKGCesbkYw6tS0DPYucApNVQrKqg=
@@ -246,6 +257,7 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/index.tmpl.html
+++ b/index.tmpl.html
@@ -757,6 +757,17 @@
             color: var(--accent);
         }
 
+        .footer {
+            text-align: center;
+            font-size: small
+        }
+
+        .lists {
+            text-align: center;
+            list-style-type: none;
+            padding: 0;
+            margin:0;
+        }
     </style>
     <script>
         document.addEventListener("DOMContentLoaded", function () {
@@ -812,6 +823,11 @@
     <button type="submit">RGL Team History</button>
 </form>
 
+<form action="/league_bans" method="get">
+    <input type="text" name="steamids" placeholder="steamid|vanity name|profile url">
+    <button type="submit">Comp League Bans</button>
+</form>
+
 <form method="get" id="log">
     <input type="text" name="steamids" placeholder="12345">
     <button type="submit">Log By ID</button>
@@ -836,13 +852,19 @@
     <button type="submit" style="width: 99%">serveme.tf Bans</button>
 </form>
 
-<h5>Bot Detector Ban Lists<br /><a href="/list/rgl">rgl.gg</a><br /><a href="/list/serveme">serveme.tf</a></h5>
+<h5>Bot Detector Ban Lists</h5>
 
-<h6>
+<ul class="lists">
+    <li><a href="/list/etf2l">etf2l.org</a></li>
+    <li><a href="/list/rgl">rgl.gg</a></li>
+    <li><a href="/list/serveme">serveme.tf</a></li>
+</ul>
+
+<p class="footer">
     <a href="https://github.com/leighmacdonald/bd-api/blob/master/docs/API.md">API</a>
-    <a href="/stats">Stats</a>
-    <br/>
+    <a href="/stats">Stats</a><br />
     {{ .Version }}
-</h6>
+</p>
+
 </body>
 </html>

--- a/main.go
+++ b/main.go
@@ -105,6 +105,11 @@ func run(ctx context.Context) int {
 		go rglScraper.start(ctx)
 	}
 
+	if config.ETF2LScraperEnabled {
+		etf2lScraper := NewETF2LScraper(database)
+		go etf2lScraper.start(ctx)
+	}
+
 	if config.SourcebansScraperEnabled {
 		if err := runSourcebansScraper(ctx, database, config); err != nil {
 			slog.Error("failed to init sourcebans scraper", ErrAttr(err))

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 )
 
-var version = "1.0.7"
+var version = "1.0.8"
 
 func createAppDeps(ctx context.Context) (appConfig, cache, *pgStore, error) {
 	var config appConfig

--- a/migrations/0006_etf2l_ban_table.down.sql
+++ b/migrations/0006_etf2l_ban_table.down.sql
@@ -1,0 +1,5 @@
+begin;
+
+DROP TABLE IF EXISTS etf2l_ban;
+
+commit;

--- a/migrations/0006_etf2l_ban_table.up.sql
+++ b/migrations/0006_etf2l_ban_table.up.sql
@@ -1,0 +1,13 @@
+begin;
+
+CREATE TABLE IF NOT EXISTS etf2l_ban (
+    steam_id bigint not null references player (steam_id),
+    alias text not null,
+    created_at timestamptz not null,
+    expires_at timestamptz not null,
+    reason text not null
+);
+
+CREATE UNIQUE INDEX etf2l_ban_idx ON etf2l_ban (steam_id, created_at);
+
+commit;


### PR DESCRIPTION
Indexes etf2l ban lists via API.


Some are missing due to 500 errors when querying the following ban pages: 18,26,27,31,69,83,85,124,178

- Add form to index
- Adds league_bans to player profile response
- Adds bot detector list
